### PR TITLE
Fix multi-channel (5.1/7.1) input only spatializing FL/FR (#4)

### DIFF
--- a/Airwave/AirwaveMenuView.swift
+++ b/Airwave/AirwaveMenuView.swift
@@ -403,7 +403,8 @@ struct AirwaveMenuView: View {
                                 isSelected: preset.id == hrirManager.activePreset?.id
                             ) {
                                 let sampleRate = 48000.0
-                                let inputLayout = InputLayout.detect(channelCount: 2)
+                                let channelCount = audioManager.selectedInputDevice?.inputChannelRange?.count ?? 2
+                                let inputLayout = InputLayout.detect(channelCount: channelCount)
                                 hrirManager.activatePreset(preset, targetSampleRate: sampleRate, inputLayout: inputLayout)
                             }
                         }

--- a/Airwave/AudioGraphManager.swift
+++ b/Airwave/AudioGraphManager.swift
@@ -834,24 +834,21 @@ private func renderCallback(
         }
     }
     
-    // Determine which input channels to use (first 2 from selected input device)
+    // Determine which input channels to use (selected range from input device)
     let inputRange = manager.selectedInputChannelRange ?? 0..<min(2, inputChannelCount)
     let leftInputChannel = inputRange.lowerBound
     let rightInputChannel = min(leftInputChannel + 1, inputRange.upperBound - 1)
-    
+
     let shouldProcess = manager.hrirManager?.isConvolutionActive ?? false
-    
+
     if shouldProcess, let channelPtrs = manager.inputChannelBufferPtrs {
-        // Create a temporary 2-channel pointer array for stereo input
-        let stereoInputPtrs = UnsafeMutablePointer<UnsafeMutablePointer<Float>>.allocate(capacity: 2)
-        defer { stereoInputPtrs.deallocate() }
-        
-        stereoInputPtrs[0] = channelPtrs[leftInputChannel]
-        stereoInputPtrs[1] = channelPtrs[rightInputChannel]
-        
+        // Feed every channel in the selected range so multi-channel presets
+        // (5.1/7.1) can drive more than just the first two speakers
+        let channelCount = max(0, min(inputRange.count, inputChannelCount - leftInputChannel))
+
         manager.hrirManager?.processAudio(
-            inputPtrs: stereoInputPtrs,
-            inputCount: 2,  // Always stereo input
+            inputPtrs: channelPtrs.advanced(by: leftInputChannel),
+            inputCount: channelCount,
             leftOutput: manager.outputStereoLeftPtr,
             rightOutput: manager.outputStereoRightPtr,
             frameCount: frameCount

--- a/Airwave/MenuBarViewModel.swift
+++ b/Airwave/MenuBarViewModel.swift
@@ -332,11 +332,10 @@ class MenuBarViewModel: ObservableObject {
                    let input = audioManager.availableInputs.first(where: { $0.uid == inputUID }) {
                     Logger.log("[MenuBarViewModel] Restoring input device: \(input.name)")
                     audioManager.selectedInputDevice = input
-                    
+
                     // Set the input channel range
                     if let inputRange = input.inputChannelRange {
-                        let stereoRange = inputRange.lowerBound..<min(inputRange.lowerBound + 2, inputRange.upperBound)
-                        audioManager.setInputChannels(stereoRange)
+                        audioManager.setInputChannels(inputRange)
                     }
                     
                     // Persist the restored input device
@@ -345,11 +344,10 @@ class MenuBarViewModel: ObservableObject {
                     // Fallback to first input
                     Logger.log("[MenuBarViewModel] Auto-selecting first input device: \(firstInput.name)")
                     audioManager.selectedInputDevice = firstInput
-                    
+
                     // Set the input channel range
                     if let inputRange = firstInput.inputChannelRange {
-                        let stereoRange = inputRange.lowerBound..<min(inputRange.lowerBound + 2, inputRange.upperBound)
-                        audioManager.setInputChannels(stereoRange)
+                        audioManager.setInputChannels(inputRange)
                     }
                     
                     // Persist the auto-selected input device
@@ -377,7 +375,8 @@ class MenuBarViewModel: ObservableObject {
            let preset = hrirManager.presets.first(where: { $0.id == presetID }) {
             Logger.log("[MenuBarViewModel] Restoring preset: \(preset.name)")
             let sampleRate = 48000.0
-            let inputLayout = InputLayout.detect(channelCount: 2)
+            let channelCount = audioManager.selectedInputDevice?.inputChannelRange?.count ?? 2
+            let inputLayout = InputLayout.detect(channelCount: channelCount)
             hrirManager.activatePreset(preset, targetSampleRate: sampleRate, inputLayout: inputLayout)
         }
         

--- a/Airwave/SettingsView.swift
+++ b/Airwave/SettingsView.swift
@@ -394,7 +394,8 @@ struct SettingsView: View {
                         set: { newID in
                             if let preset = hrirManager.presets.first(where: { $0.id == newID }) {
                                 let sampleRate = 48000.0
-                                let inputLayout = InputLayout.detect(channelCount: 2)
+                                let channelCount = audioManager.selectedInputDevice?.inputChannelRange?.count ?? 2
+                                let inputLayout = InputLayout.detect(channelCount: channelCount)
                                 hrirManager.activatePreset(preset, targetSampleRate: sampleRate, inputLayout: inputLayout)
                             } else {
                                 hrirManager.activePreset = nil
@@ -829,11 +830,10 @@ struct SettingsView: View {
         }
         
         audioManager.selectedInputDevice = input
-        
-        // Set the input channel range to the first 2 channels of the selected input device
+
+        // Set the input channel range to the selected input device's full range
         if let inputRange = input.inputChannelRange {
-            let stereoRange = inputRange.lowerBound..<min(inputRange.lowerBound + 2, inputRange.upperBound)
-            audioManager.setInputChannels(stereoRange)
+            audioManager.setInputChannels(inputRange)
         }
         
         // Only switch system audio output if explicitly requested AND audio engine is running
@@ -922,8 +922,7 @@ struct SettingsView: View {
                 
                 // Update the input channel range in case it changed
                 if let inputRange = stillExists.inputChannelRange {
-                    let stereoRange = inputRange.lowerBound..<min(inputRange.lowerBound + 2, inputRange.upperBound)
-                    audioManager.setInputChannels(stereoRange)
+                    audioManager.setInputChannels(inputRange)
                 }
                 
                 // Persist the input device to ensure it's saved

--- a/Airwave/VirtualSpeaker.swift
+++ b/Airwave/VirtualSpeaker.swift
@@ -92,6 +92,14 @@ struct InputLayout {
         case 8: return .surround71
         case 12: return .atmos714
         default:
+            // Virtual audio drivers (e.g. BlackHole 16ch) often expose more channels
+            // than the source uses, so fall back to the largest known surround layout
+            // that fits within what's available
+            if channelCount > 12 { return .atmos714 }
+            if channelCount > 8 { return .surround71 }
+            if channelCount > 6 { return .surround51 }
+            if channelCount > 2 { return .stereo }
+
             // Create a generic layout with custom speakers
             let channels = (0..<channelCount).map { VirtualSpeaker.custom("Ch\($0)") }
             return InputLayout(channels: channels, name: "\(channelCount) Channel")


### PR DESCRIPTION
## Summary

Fixes #4 — multi-channel input (5.1/7.1) was only ever spatializing the first two input channels (FL/FR); everything else was silently dropped.

The multi-channel HRIR rendering engine (`HRIRManager`, `ConvolutionEngine`, the HeSuVi channel maps in `VirtualSpeaker.swift`) was already fully built to handle 5.1/7.1/7.1.4 — it just never received more than 2 channels of real audio, because five separate places independently hardcoded a 2-channel assumption:

1. **`AudioGraphManager.swift` render callback** — always extracted exactly 2 raw input channels and passed `inputCount: 2` to `HRIRManager.processAudio`, no matter how many channels were actually selected or how many speaker renderers had been built.
2. **`VirtualSpeaker.swift` `InputLayout.detect(channelCount:)`** — only recognized *exact* channel counts of 2/6/8/12. Virtual drivers like BlackHole only ship in 2/16/64‑channel variants, so a real 16‑channel device fell through to a useless generic per-channel layout with zero HRIR mappings, and preset activation failed outright.
3. **`SettingsView.swift`** (×2) and **`MenuBarViewModel.swift`** (×2) — clamped `selectedInputChannelRange` to the first 2 channels of whatever input device was picked, regardless of its real channel count.
4. **`SettingsView.swift`, `AirwaveMenuView.swift`, `MenuBarViewModel.swift`** — each independently hardcoded `InputLayout.detect(channelCount: 2)` when activating a preset from the UI, overriding whatever multi-channel layout had been correctly detected elsewhere.

## Fix

- Render callback now feeds every channel in the selected input range into `HRIRManager.processAudio` (and does it without a per-callback heap allocation, which the old 2-channel temp buffer required).
- `InputLayout.detect` falls back to the largest known surround layout that fits within the available channel count, instead of only matching exact counts. Every layout in this codebase is an ordered prefix of the next (stereo ⊂ 5.1 ⊂ 7.1 ⊂ 7.1.4), so this is always a safe "use what applies, ignore the rest" choice — never a mis-assignment.
- The three "clamp to 2 channels" sites now pass through the input device's full channel range.
- The three "hardcode 2 for preset activation" sites now read the real selected input device's channel count.

## Testing

Verified on real hardware (BlackHole 16ch + physical DAC in an Aggregate Device, HeSuVi HRIR preset), A/B against unmodified `main`, using the app's own debug log to count `ConvolutionEngine` initializations during preset activation:

| | Input channels wired | Renderers built |
|---|---|---|
| `main` (before) | `0-1` | 4 (FL/FR only) |
| this branch (after) | `0-15` | 16 (FL,FR,FC,LFE,BL,BR,SL,SR — full 7.1) |

5.1 / 5.1.2 sources are correctly spatialized end-to-end. For 7.1 sources, correctness now depends on the *source* and macOS's own channel-role assignment agreeing with the standard FL,FR,FC,LFE,BL,BR,SL,SR ordering this app (and HeSuVi) assumes — see the setup notes below, which materially affects whether rear vs. side channels land correctly.

## Setup notes for testers (5.1/7.1 via BlackHole)

1. **Aggregate Device**: combine your virtual driver (BlackHole 16ch) as input with your real output device, with Drift Correction enabled only on the virtual driver.
<img width="1134" height="915" alt="aggregate_device_setup" src="https://github.com/user-attachments/assets/f96886cb-d916-4d1c-913d-8957ad6e7eab" />
2. On the virtual driver's own pane (e.g. **BlackHole 16ch → Output**), use **Configure Speakers…** to assign macOS's semantic channel roles to the right channel numbers.
<img width="1134" height="915" alt="channel_setup_0" src="https://github.com/user-attachments/assets/ef390461-d892-473f-8b03-ee2a51035c52" />
3. In the **Configure Layout** dialog, pick **"7.1 Rear Surround"** (not plain "7.1" — that variant uses Left‑center/Right‑center instead of true rear‑surround roles) and assign Left/Right/Center/Sub/Left+Right surround/Left+Right rear surround to match the channel order Airwave expects (FL,FR,FC,LFE,BL,BR,SL,SR).
<img width="1134" height="915" alt="channel_setup_1" src="https://github.com/user-attachments/assets/1e9bcea5-4a7a-4efd-a032-7d7249dd72d2" />
4. Confirm in Airwave's menu bar device list that the aggregate shows the expected input/output channel counts before starting the engine.
<img width="267" height="624" alt="sound_in_out_setup" src="https://github.com/user-attachments/assets/7e2387d3-b7c9-4f17-a5fb-9671ba4e6a63" />

## Notes / follow-ups not covered by this PR

- Channel-order conventions for the "rear vs. side" pair in 7.1 aren't universally standardized across sources (browsers, media players, games each make their own choice), so some sources may still need the OS-level remap above to sound correct — a future enhancement could let users override the channel-to-speaker mapping directly in Airwave rather than relying entirely on the OS assignment.
- Switching an output device's connection type (e.g. Qudelix-5K Bluetooth ↔ USB) mid-session can transiently clear the saved aggregate/input/output device UIDs if the device briefly fails its "still exists" check during the handoff; it currently self-heals once the device resolves again, but isn't hardened against a permanent loss during that window. Flagging as a separate follow-up, not fixed here.
